### PR TITLE
Nationalities other ids

### DIFF
--- a/client_registry/client_registry/doctype/client_registry/client_registry.json
+++ b/client_registry/client_registry/doctype/client_registry/client_registry.json
@@ -87,7 +87,8 @@
    "fieldname": "first_name",
    "fieldtype": "Data",
    "label": "First Name",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "middle_name",
@@ -98,7 +99,8 @@
    "fieldname": "last_name",
    "fieldtype": "Data",
    "label": "Last Name",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_5",
@@ -109,13 +111,15 @@
    "fieldtype": "Link",
    "label": "Gender",
    "options": "Gender",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "date_of_birth",
    "fieldtype": "Date",
    "label": "Date of birth",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "phone",
@@ -137,7 +141,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Identification Number",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_14",
@@ -149,7 +154,8 @@
    "fieldtype": "Link",
    "label": "Identification Type",
    "options": "Identification Type",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "dependants",
@@ -501,7 +507,7 @@
  "image_field": "banner_image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-02 17:05:53.954466",
+ "modified": "2024-03-03 05:39:11.831250",
  "modified_by": "Administrator",
  "module": "Client Registry",
  "name": "Client Registry",

--- a/client_registry/client_registry/doctype/client_registry/client_registry.py
+++ b/client_registry/client_registry/doctype/client_registry/client_registry.py
@@ -117,9 +117,9 @@ class ClientRegistry(Document):
 			"phone": doc.get_masked_string("phone") or "" if not unmask else doc.get("phone"),
    			"biometrics_verified": doc.get("biometrics_verified") or 0,
 			"biometrics_score": doc.get("aws_rekognition_match") or 0,
-			"email": doc.get("email") or "",
+			"email": doc.get_masked_string("email") or "" if not unmask else doc.get("email"),
 			"country": doc.get("country") or "",
-			"county": doc.get("country") or "",
+			"county": doc.get("county") or "",
 			"sub_county": doc.get("sub_county") or "",
 			"ward": doc.get("ward") or "",
 			"village_estate": doc.get("village_estate") or "",
@@ -149,7 +149,7 @@ class ClientRegistry(Document):
 		# frappe.msgprint("{}".format(fhir))
 		# if not fhir.get
 		return fhir
-	def get_masked_string(self, fieldname, plain_str=None):
+	def get_masked_string(self, fieldname, plain_str=None,num_visible=3):
 		s = plain_str or self.get(fieldname) or ""
 		if not s: return ""
 		return self.mask_digits(s, num_visible=3)


### PR DESCRIPTION
1. `/reset-pin` now accepts `phone`: When this is provided a Client is updated appropriately. Tested.
2.` /update-client` now requires jwt token provided with  `encoded_pin` as the key.
3. `/uar-cr-registration` returns **masked** personal identifiable information as below:

```
-first_name
-middle_name
-last_name
-date_of_birth
-citizenship
-phone
-email
```
4. `/fetch-client` returns **unmasked** personal-identifiable information.
NB: Please use 4 only when logged in. It is not secured with PIN because it is used by EMRs to fetch info about a client and EMRs will be onboarded to the exchange. Good luck to the C# guys logging in to an EMR and mining our data.


`{
    "message": {
        "resourceType": "Patient",
        "id": "27613716-002-P-5",
        "meta": {
            "versionId": "1",
            "creationTime": "2024-03-01 02:46:09.787891",
            "lastUpdated": "2024-03-04 12:08:16.847916",
            "source": "http://cr.kns.co.ke"
        },
        "originSystem": {
            "system": "SAFARICOM PLC-89204020",
            "record_id": ""
        },
        "title": "",
        "first_name": "**LIM",
        "middle_name": "***URA",
        "last_name": "*URU",
        "gender": "Male",
        "date_of_birth": "***0-*5-*2",
        "place_of_birth": "MAKUENI\nDISTRICT - MAKUENI\n",
        "person_with_disability": 0,
        "citizenship": "***YAN",
        "kra_pin": "",
        "preferred_primary_care_network": "",
        "employment_type": "Employed",
        "civil_status": "",
        "identification_type": "National ID",
        "identification_number": "27613716",
        "other_identifications": [],
        "dependants": [],
        "is_alive": 1,
        "deceased_datetime": "",
        "phone": "**********063",
        "biometrics_verified": 0,
        "biometrics_score": 0,
        "email": "************.ke",
        "country": "Lithuania",
        "county": "",
        "sub_county": "",
        "ward": "",
        "village_estate": "",
        "building_house_no": "",
        "latitude": "",
        "longitude": "",
        "province_state_country": "",
        "zip_code": "",
        "identification_residence": "BOX 10 MATILIKU\nKAMBUL\nNG'ETHA\nLOCATION - MULALA\nDIVISION - MULALA\nDISTRICT - NZAUI\n",
        "employer_name": null,
        "employer_pin": "",
        "disability_category": "",
        "disability_subcategory": "",
        "disability_cause": "",
        "in_lawful_custody": "",
        "admission_remand_number": "",
        "document_uploads": []
    }
}`
      